### PR TITLE
Fixed syntax error in generated code in case of multiple possible res…

### DIFF
--- a/src/main/resources/v2/JavaSpring/api.mustache
+++ b/src/main/resources/v2/JavaSpring/api.mustache
@@ -86,7 +86,7 @@ public interface {{classname}} {
         {{/hasMore}}{{/authMethods}}
     }{{/has}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}",{{/vendorExtensions.x-tags}} })
     @ApiResponses(value = { {{#responses}}
-        @ApiResponse(code = {{{code}}}, message = "{{{message}}}"{{#baseType}}, response = {{{baseType}}}.class{{/baseType}}{{#containerType}}, responseContainer = "{{{containerType}}}"{{/containerType}}){{#has this 'more'}},,{{/has}}{{/responses}} })
+        @ApiResponse(code = {{{code}}}, message = "{{{message}}}"{{#baseType}}, response = {{{baseType}}}.class{{/baseType}}{{#containerType}}, responseContainer = "{{{containerType}}}"{{/containerType}}){{#has this 'more'}},{{/has}}{{/responses}} })
     {{#implicitHeaders}}
     @ApiImplicitParams({
     {{#headerParams}}


### PR DESCRIPTION
…ponses.

Fixed syntax error in generated code in case of multiple possible responses. The generator generated two commas to seperate the responses, which causes a syntax error. I corrected it to only one comma.